### PR TITLE
[Makefile] Fix Makefile: Exclude "index.md", but also "index.ba.md" and "index.ma.md"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ SLIDES_EXCLUDE_DIRS            = $(dir $(shell find $(SRC_DIR) -type f -iname '.
 SLIDES_BUNDLE_MARKDOWN_SOURCES = $(filter-out $(addsuffix %, $(SLIDES_EXCLUDE_DIRS)), $(shell find $(SRC_DIR) -type f -iname 'index.md'))
 SLIDES_BUNDLE_PDF_TARGETS      = $(addprefix $(SLIDES_OUTPUT_DIR)/,$(subst /,_, $(patsubst $(SRC_DIR)/%/index.md,%.pdf, $(SLIDES_BUNDLE_MARKDOWN_SOURCES))))
 ## Single markdown files
-SLIDES_SINGLE_MARKDOWN_SOURCES = $(filter-out $(addsuffix %, $(SLIDES_EXCLUDE_DIRS)), $(shell find $(SRC_DIR) -type f -iname '*.md'  ! -iname '*index.md' ! -iname 'tldr.md' ! -iname 'outcomes.md'))
+SLIDES_SINGLE_MARKDOWN_SOURCES = $(filter-out $(addsuffix %, $(SLIDES_EXCLUDE_DIRS)), $(shell find $(SRC_DIR) -type f -iname '*.md'  ! -iname '*index*.md' ! -iname 'tldr.md' ! -iname 'outcomes.md'))
 SLIDES_SINGLE_PDF_TARGETS      = $(addprefix $(SLIDES_OUTPUT_DIR)/,$(subst /,_, $(patsubst $(SRC_DIR)/%.md,%.pdf, $(SLIDES_SINGLE_MARKDOWN_SOURCES))))
 ## Convenience targets
 SLIDES_MARKDOWN_TARGETS        = $(SLIDES_BUNDLE_MARKDOWN_SOURCES:$(SRC_DIR)%=$(SLIDES_INTERMEDIATE_DIR)%) $(SLIDES_SINGLE_MARKDOWN_SOURCES:$(SRC_DIR)%=$(SLIDES_INTERMEDIATE_DIR)%)


### PR DESCRIPTION
`_index.md` und `index.md` werden vom Makefile als potentielle Targets für die Erstellung von Slides ignoriert. 

Bei der Umstellung auf "Multi-Language" (Bachelor "ba", Master "ma") bekamen alle Markdowndateien einen zusätzlichen Anhang ".ba" bzw. ".ma" zwischen Dateinamen und Dateiendung. Dadurch funktionierte das Ignorieren der Index-Dateien nicht mehr.

Dieser PR behebt das Problem: Das Makefile ignoriert nun alle `*index*.md` beim Erstellen der Slides.

fixes #73