### PR TITLE
[VL] LL-Parser und Error-Recovery

### DIFF
--- a/markdown/frontend/parsing/finalwords.ba.md
+++ b/markdown/frontend/parsing/finalwords.ba.md
@@ -119,7 +119,7 @@ Vorname Name: +49.571.8385-268
     einfach entfernt ...
     :::
 
-    ``` {.yacc size="scriptsize"}
+    ``` {.antlr size="scriptsize"}
     addrbk : ROW+;
     ROW    : '\n';
     OTHER  : ~'\n' -> skip ;
@@ -135,7 +135,7 @@ Vorname Name: +49.571.8385-268
     (und -Fragmenten) zu erkennen.
     :::
 
-    ``` {.yacc size="scriptsize"}
+    ``` {.antlr size="scriptsize"}
     addrbk  : row+;
     row     : SURNAME NAME ':' TELNR;
     ```
@@ -150,7 +150,7 @@ Vorname Name: +49.571.8385-268
     Adressen entsprechend eine Parser-Regel sein:
     :::
 
-    ``` {.yacc size="scriptsize"}
+    ``` {.antlr size="scriptsize"}
     addrbk  : row+;
     row     : SURNAME NAME ':' telnr;
    ```

--- a/markdown/frontend/parsing/finalwords.ma.md
+++ b/markdown/frontend/parsing/finalwords.ma.md
@@ -119,7 +119,7 @@ Vorname Name: +49.571.8385-268
     einfach entfernt ...
     :::
 
-    ``` {.yacc size="scriptsize"}
+    ``` {.antlr size="scriptsize"}
     addrbk : ROW+;
     ROW    : '\n';
     OTHER  : ~'\n' -> skip ;
@@ -135,7 +135,7 @@ Vorname Name: +49.571.8385-268
     (und -Fragmenten) zu erkennen.
     :::
 
-    ``` {.yacc size="scriptsize"}
+    ``` {.antlr size="scriptsize"}
     addrbk  : row+;
     row     : SURNAME NAME ':' TELNR;
     ```
@@ -150,7 +150,7 @@ Vorname Name: +49.571.8385-268
     Adressen entsprechend eine Parser-Regel sein:
     :::
 
-    ``` {.yacc size="scriptsize"}
+    ``` {.antlr size="scriptsize"}
     addrbk  : row+;
     row     : SURNAME NAME ':' telnr;
    ```

--- a/markdown/frontend/parsing/ll-advanced.ma.md
+++ b/markdown/frontend/parsing/ll-advanced.ma.md
@@ -64,7 +64,7 @@ wuppie() { ...}   // Definition
 
 [Entsprechend sähe die Grammatik aus:]{.notes}
 
-```yacc
+```antlr
 func : fdef | fdecl ;
 fdef : head '{' body '}' ;
 fdecl: head ';' ;
@@ -99,7 +99,7 @@ entsprechend Vorrangregeln implementieren.
 
 Man könnte die obige Grammatik umformen ...
 
-```yacc
+```antlr
 func : head ('{' body '}' | ';') ;
 head : ... ;
 ```
@@ -279,7 +279,7 @@ zurücksetzt, werden alle `*_memo` ungültig und müssen ebenfalls zurückgesetz
 
 Problem in Java: `enum` ab Java5 Schlüsselwort [(vorher als Identifier-Name verwendbar)]{.notes}
 
-```yacc
+```antlr
 prog : (enumDecl | stat)+ ;
 stat : ... ;
 
@@ -310,7 +310,7 @@ def prog():
 ### Semantische Prädikate in Parser-Regeln
 :::
 
-```yacc
+```antlr
 @parser::members {public static boolean java5;}
 
 prog : ({java5}? enumDecl | stat)+ ;
@@ -328,7 +328,7 @@ des Prädikats gematcht werden könnte.
 Alternativ für Lexer-Regeln:
 :::
 
-```yacc
+```antlr
 ENUM : 'enum' {java5}? ;
 ID   : [a-zA-Z]+ ;
 ```

--- a/markdown/frontend/parsing/ll-parser-impl.ba.md
+++ b/markdown/frontend/parsing/ll-parser-impl.ba.md
@@ -38,7 +38,7 @@ outcomes:
   - k2: "Prinzipieller Aufbau von LL-Parsern"
   - k3: "Implementierung von LL(1)- und LL(k)-Parsern"
   - k3: "Implementierung von Vorrang und Assoziativität"
-  - k3: "Umgang mit Linksrekursion, insbesondere bei ANTLR4"
+  - k3: "Umgang mit Linksrekursion, insbesondere bei ANTLR"
 assignments:
   - topic: sheet01
 youtube:
@@ -312,7 +312,7 @@ multExpr : INT ('*' INT)* ;
 ```
 
 ::: notes
-ANTLR4 kann Grammatiken mit *direkter* Linksrekursion auflösen. Für frühere Versionen von ANTLR muss man die
+ANTLR (v4) kann Grammatiken mit *direkter* Linksrekursion auflösen. Für frühere Versionen von ANTLR muss man die
 Rekursion manuell beseitigen.
 
 Vergleiche ["ALL(\*)" bzw. "Adaptive LL(\*)"](https://www.antlr.org/papers/allstar-techreport.pdf).
@@ -323,7 +323,7 @@ Vergleiche ["ALL(\*)" bzw. "Adaptive LL(\*)"](https://www.antlr.org/papers/allst
 \bigskip
 \pause
 
-**Achtung**: Mit *indirekter* Linksrekursion kann ANTLR4 *nicht* umgehen:
+**Achtung**: Mit *indirekter* Linksrekursion kann ANTLR (v4) *nicht* umgehen:
 
 ```antlr
 expr : expM | ... ;

--- a/markdown/frontend/parsing/ll-parser-impl.ba.md
+++ b/markdown/frontend/parsing/ll-parser-impl.ba.md
@@ -50,7 +50,7 @@ fhmedia:
 ---
 
 
-## Erinnerung Lexer: Zeichenstrom $\to$ Tokenstrom
+## Erinnerung Lexer: Zeichenstrom => Tokenstrom
 
 ``` {.python size="footnotesize"}
 def nextToken():

--- a/markdown/frontend/parsing/ll-parser-impl.ba.md
+++ b/markdown/frontend/parsing/ll-parser-impl.ba.md
@@ -88,7 +88,7 @@ in den Puffer einlesen.
 
 [Grammatik:]{.notes}
 
-```yacc
+```antlr
 r : X s ;
 ```
 
@@ -187,7 +187,7 @@ while True:
 
 [Beispiel: Parsen von Listen, also Sequenzen wie `[1,2,3,4]`:]{.notes}
 
-```yacc
+```antlr
 list     : '[' elements ']' ;
 elements : INT (',' INT)* ;
 
@@ -262,7 +262,7 @@ durchgereicht) über den Aufruf der Start-Regel, also beispielsweise `parser.lis
 
 [Dies formuliert man üblicherweise in der Grammatik:]{.notes}
 
-```yacc
+```antlr
 expr : expr '+' term
      | term
      ;
@@ -280,7 +280,7 @@ unter Beibehaltung der Vorrangregeln so in ANTLR (v4) formulieren:
 \pause
 \bigskip
 
-```yacc
+```antlr
 expr : expr '*' expr
      | expr '+' expr
      | INT
@@ -297,7 +297,7 @@ manuell auflösen und die Grammatik umschreiben.
 **Beispiel**:
 :::
 
-```yacc
+```antlr
 expr : expr '*' expr | expr '+' expr | INT ;
 ```
 
@@ -305,7 +305,7 @@ expr : expr '*' expr | expr '+' expr | INT ;
 
 [Diese linksrekursive Grammatik könnte man (unter Beachtung der Vorrangregeln) etwa so umformulieren:]{.notes}
 
-```yacc
+```antlr
 expr     : addExpr ;
 addExpr  : multExpr ('+' multExpr)* ;
 multExpr : INT ('*' INT)* ;
@@ -325,7 +325,7 @@ Vergleiche ["ALL(\*)" bzw. "Adaptive LL(\*)"](https://www.antlr.org/papers/allst
 
 **Achtung**: Mit *indirekter* Linksrekursion kann ANTLR4 *nicht* umgehen:
 
-```yacc
+```antlr
 expr : expM | ... ;
 expM : expr '*' expr ;
 ```
@@ -343,7 +343,7 @@ Die Eingabe `2^3^4` sollte als `2^(3^4)` geparst werden.  [Analog sollte `a=b=c`
 Per Default werden Operatoren wie `+` in ANTLR *links-assoziativ* behandelt, d.h. die Eingabe `1+2+3` wird
 als `(1+2)+3` gelesen. Für *rechts-assoziative* Operatoren muss man ANTLR dies in der Grammatik mitteilen:
 
-```yacc
+```antlr
 expr : expr '^'<assoc=right> expr
      | INT
      ;
@@ -358,7 +358,7 @@ ignoriert?!
 
 ## LL(k)-Parser
 
-```yacc
+```antlr
 expr : ID '++'    // x++
      | ID '--'    // x--
      ;
@@ -375,7 +375,7 @@ umschreiben:
 \bigskip
 \pause
 
-```yacc
+```antlr
 expr : ID ('++' | '--') ;    // x++ oder x--
 ```
 

--- a/markdown/frontend/parsing/ll-parser-impl.ma.md
+++ b/markdown/frontend/parsing/ll-parser-impl.ma.md
@@ -38,7 +38,7 @@ outcomes:
   - k2: "Prinzipieller Aufbau von LL-Parsern"
   - k3: "Implementierung von LL(1)- und LL(k)-Parsern"
   - k3: "Implementierung von Vorrang und Assoziativität"
-  - k3: "Umgang mit Linksrekursion, insbesondere bei ANTLR4"
+  - k3: "Umgang mit Linksrekursion, insbesondere bei ANTLR"
 assignments:
   - topic: sheet01
 youtube:
@@ -312,7 +312,7 @@ multExpr : INT ('*' INT)* ;
 ```
 
 ::: notes
-ANTLR4 kann Grammatiken mit *direkter* Linksrekursion auflösen. Für frühere Versionen von ANTLR muss man die
+ANTLR (v4) kann Grammatiken mit *direkter* Linksrekursion auflösen. Für frühere Versionen von ANTLR muss man die
 Rekursion manuell beseitigen.
 
 Vergleiche ["ALL(\*)" bzw. "Adaptive LL(\*)"](https://www.antlr.org/papers/allstar-techreport.pdf).
@@ -323,7 +323,7 @@ Vergleiche ["ALL(\*)" bzw. "Adaptive LL(\*)"](https://www.antlr.org/papers/allst
 \bigskip
 \pause
 
-**Achtung**: Mit *indirekter* Linksrekursion kann ANTLR4 *nicht* umgehen:
+**Achtung**: Mit *indirekter* Linksrekursion kann ANTLR (v4) *nicht* umgehen:
 
 ```antlr
 expr : expM | ... ;

--- a/markdown/frontend/parsing/ll-parser-impl.ma.md
+++ b/markdown/frontend/parsing/ll-parser-impl.ma.md
@@ -50,7 +50,7 @@ fhmedia:
 ---
 
 
-## Erinnerung Lexer: Zeichenstrom $\to$ Tokenstrom
+## Erinnerung Lexer: Zeichenstrom => Tokenstrom
 
 ``` {.python size="footnotesize"}
 def nextToken():

--- a/markdown/frontend/parsing/ll-parser-impl.ma.md
+++ b/markdown/frontend/parsing/ll-parser-impl.ma.md
@@ -88,7 +88,7 @@ in den Puffer einlesen.
 
 [Grammatik:]{.notes}
 
-```yacc
+```antlr
 r : X s ;
 ```
 
@@ -187,7 +187,7 @@ while True:
 
 [Beispiel: Parsen von Listen, also Sequenzen wie `[1,2,3,4]`:]{.notes}
 
-```yacc
+```antlr
 list     : '[' elements ']' ;
 elements : INT (',' INT)* ;
 
@@ -262,7 +262,7 @@ durchgereicht) über den Aufruf der Start-Regel, also beispielsweise `parser.lis
 
 [Dies formuliert man üblicherweise in der Grammatik:]{.notes}
 
-```yacc
+```antlr
 expr : expr '+' term
      | term
      ;
@@ -280,7 +280,7 @@ unter Beibehaltung der Vorrangregeln so in ANTLR (v4) formulieren:
 \pause
 \bigskip
 
-```yacc
+```antlr
 expr : expr '*' expr
      | expr '+' expr
      | INT
@@ -297,7 +297,7 @@ manuell auflösen und die Grammatik umschreiben.
 **Beispiel**:
 :::
 
-```yacc
+```antlr
 expr : expr '*' expr | expr '+' expr | INT ;
 ```
 
@@ -305,7 +305,7 @@ expr : expr '*' expr | expr '+' expr | INT ;
 
 [Diese linksrekursive Grammatik könnte man (unter Beachtung der Vorrangregeln) etwa so umformulieren:]{.notes}
 
-```yacc
+```antlr
 expr     : addExpr ;
 addExpr  : multExpr ('+' multExpr)* ;
 multExpr : INT ('*' INT)* ;
@@ -325,7 +325,7 @@ Vergleiche ["ALL(\*)" bzw. "Adaptive LL(\*)"](https://www.antlr.org/papers/allst
 
 **Achtung**: Mit *indirekter* Linksrekursion kann ANTLR4 *nicht* umgehen:
 
-```yacc
+```antlr
 expr : expM | ... ;
 expM : expr '*' expr ;
 ```
@@ -343,7 +343,7 @@ Die Eingabe `2^3^4` sollte als `2^(3^4)` geparst werden.  [Analog sollte `a=b=c`
 Per Default werden Operatoren wie `+` in ANTLR *links-assoziativ* behandelt, d.h. die Eingabe `1+2+3` wird
 als `(1+2)+3` gelesen. Für *rechts-assoziative* Operatoren muss man ANTLR dies in der Grammatik mitteilen:
 
-```yacc
+```antlr
 expr : expr '^'<assoc=right> expr
      | INT
      ;
@@ -358,7 +358,7 @@ ignoriert?!
 
 ## LL(k)-Parser
 
-```yacc
+```antlr
 expr : ID '++'    // x++
      | ID '--'    // x--
      ;
@@ -375,7 +375,7 @@ umschreiben:
 \bigskip
 \pause
 
-```yacc
+```antlr
 expr : ID ('++' | '--') ;    // x++ oder x--
 ```
 

--- a/markdown/frontend/parsing/recovery.ba.md
+++ b/markdown/frontend/parsing/recovery.ba.md
@@ -20,7 +20,7 @@ tldr: |
   geschweifte Klammer. Dieses recht einfache, aber grobe Vorgehen kann verfeinert werden, indem man versucht,
   überschüssige Token zu entfernen oder fehlender Token zu ersetzen. In ANTLR wird beispielsweise maximal ein
   fehlendes Token virtuell "ersetzt" bzw. max. ein überschüssiges Token entfernt, damit man den restlichen Code
-  weiter parsen kann. Wenn mehr als ein Token fehlt oder zuviel ist, geht ANTLR in einen "Panic Mode" und
+  weiter parsen kann. Wenn mehr als ein Token fehlt oder zu viel ist, geht ANTLR in einen "Panic Mode" und
   entfernt so lange Token aus dem Eingabestrom, bis das aktuelle Token in einem *Resynchronization Set* enthalten
   ist. Die Bildung dieser Menge erinnert an die Regeln zum Bilden der *FOLLOW*-Mengen, ist aber an den Kontext
   der "aufgerufenen" Parser-Regeln gebunden. Zusätzlich gibt es weitere komplexere Strategien zum Behandeln von
@@ -65,6 +65,8 @@ fhmedia:
         => weitere Fehler anzeigen.
         Problem: Bis wohin "gobbeln", d.h. was als Synchronisationspunkt nehmen? Semikolon?
     *   Syntaktisch fehlerhafte Programme dürfen nicht in die Zielsprache übersetzt werden!
+
+_Anmerkung_: Die folgenden Inhalte beziehen sich auf die Fehlerbehandlung in ANTLR (v4).
 :::
 
 
@@ -78,7 +80,9 @@ stmt  : 'int' ID ';' ;
 stmt2 : 'int' ID '=' ID ';'  ;
 ```
 
-[ANTLR: [VarDef.g4](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.g4), Beispiele: [VarDef.txt](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.txt)]{.bsp}
+::: slides
+[Grammatik: [VarDef.g4](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.g4), Input-Beispiele: [VarDef.txt](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.txt)]{.bsp}
+:::
 
 
 ::::::::: notes
@@ -134,9 +138,7 @@ Alternativen (Sub-Regeln) entscheiden muss.
 
 ## Überblick Recovery bei Parser-Fehlern
 
-::: center
 ![](images/recovery.png){width="80%"}
-:::
 
 ::: notes
 *   Fehler im Lexer (hier nicht weiter betrachtet):
@@ -239,7 +241,7 @@ def rule():
 => Entferne solange Token, bis aktuelles Token im "*Resynchronization Set*"
 
 
-## ANTLR: Einsatz des "*Resynchronization Set*"
+## Einsatz des "*Resynchronization Set*"
 
 ::: notes
 *   **Following Set**: Menge der Token, die direkt auf eine Regel-Referenz folgen,
@@ -268,7 +270,7 @@ expr : term '+' INT ;               // Following Set für "term": {'+'}
 
 
 ::: notes
-### Hinweis: *FOLLOW* $\ne$ *Following*
+### Hinweis: *FOLLOW* != *Following*
 
 **FOLLOW** ist die Menge aller Token, die auf eine Regel folgen können
 
@@ -310,7 +312,7 @@ angenommen, dass das aktuelle Token `':'` nicht passt.
 
 
 ::: notes
-## ANTLR: Anmerkungen Fehlerbehandlung in Sub-Regeln
+## Anmerkungen Fehlerbehandlung in Sub-Regeln
 
 Bei Sub-Regeln (d.h. eine Regel enthält Alternativen) oder Schleifenkonstrukten
 (d.h. eine Regel enthält `(...)*` oder `(...)+`) geht ANTLR etwas anders vor.
@@ -347,7 +349,7 @@ Zu Details zur Fehlerbehandlung durch ANTLR vergleiche [@Parr2014, S. 170 ff.].
 
 
 ::::::::: notes
-## ANTLR: Ändern der Fehlerbehandlungs-Strategie
+## Ändern der Fehlerbehandlungs-Strategie in ANTLR
 
 ### Ändern der Fehlerbehandlungs-Strategie (global)
 

--- a/markdown/frontend/parsing/recovery.ba.md
+++ b/markdown/frontend/parsing/recovery.ba.md
@@ -88,12 +88,12 @@ stmt  : 'int' ID ';' ;
 stmt2 : 'int' ID '=' ID ';'  ;
 ```
 
-[ANTLR4: [VarDef.g4](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.g4), Beispiele: [VarDef.txt](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.txt)]{.bsp}
+[ANTLR: [VarDef.g4](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.g4), Beispiele: [VarDef.txt](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.txt)]{.bsp}
 
 
 ::::::::: notes
 *Anmerkung*: Die nachfolgenden Fehler werden am Beispiel der Grammatik
-`[VarDef.g4](src/VarDef.g4)`{=markdown} und ANTLR4 demonstriert.
+`[VarDef.g4](src/VarDef.g4)`{=markdown} und ANTLR demonstriert.
 
 ### Lexikalische Fehler
 
@@ -324,10 +324,10 @@ angenommen, dass das aktuelle Token `':'` nicht passt.
 
 
 ::: notes
-## ANTLR4: Anmerkungen Fehlerbehandlung in Sub-Regeln
+## ANTLR: Anmerkungen Fehlerbehandlung in Sub-Regeln
 
 Bei Sub-Regeln (d.h. eine Regel enthält Alternativen) oder Schleifenkonstrukten
-(d.h. eine Regel enthält `(...)*` oder `(...)+`) geht ANTLR4 etwas anders vor.
+(d.h. eine Regel enthält `(...)*` oder `(...)+`) geht ANTLR etwas anders vor.
 
 1.  Start einer Sub-Regel/Alternative: Versuch einer *single token deletion*
 
@@ -361,7 +361,7 @@ Zu Details zur Fehlerbehandlung durch ANTLR vergleiche [@Parr2014, S. 170 ff.].
 
 
 ::::::::: notes
-## ANTLR4: Ändern der Fehlerbehandlungs-Strategie
+## ANTLR: Ändern der Fehlerbehandlungs-Strategie
 
 ### Ändern der Fehlerbehandlungs-Strategie (global)
 
@@ -415,7 +415,7 @@ Da Bison/Flex rausfliegt, sind die verbleibenden ANTRL Überschriften nicht mehr
 -->
 
 ::: notes
-### ANTLR4
+### ANTLR
 :::
 
 ```antlr
@@ -448,7 +448,7 @@ expr: ID '+' ID | INT ;
 => Was passiert bei der Eingabe: `a+b` ??! Welche Regel/Alternative soll
 jetzt matchen, d.h. welcher AST soll am Ende erzeugt werden?!
 
-### ANTLR4
+### ANTLR
 
 Nicht eindeutige Grammatiken führen **nicht** zu einer Fehlermeldung,
 da nicht der Nutzer mit seiner Eingabe Schuld ist, sondern das Problem
@@ -457,7 +457,7 @@ in der Grammatik selbst steckt.
 Während des Debuggings von Grammatiken lohnt es sich aber, diese
 Warnungen zu aktivieren. Dies kann entweder mit der Option "`-diagnostics`"
 beim Aufruf des `grun`-Tools geschehen oder über das Setzen des
-`DiagnosticErrorListener` aus der ANTLR4-Runtime als ErrorListener.
+`DiagnosticErrorListener` aus der ANTLR-Runtime als ErrorListener.
 
 
 
@@ -465,10 +465,10 @@ beim Aufruf des `grun`-Tools geschehen oder über das Setzen des
 
 *   Fehler bei `match()`: *single token deletion* oder *single token insertion*
 
-*   Panic Mode: *sync-and-return* bis Token in *Resynchronization Set* (ANTLR4)
+*   Panic Mode: *sync-and-return* bis Token in *Resynchronization Set* (ANTLR)
     oder `error`-Token shiftbar (Bison)
-    *   ANTLR4: Sonderbehandlung bei Start von Sub-Regeln und in Schleifen
-    *   ANTLR4: Fail-Save zur Vermeidung von Endlosschleifen
+    *   ANTLR: Sonderbehandlung bei Start von Sub-Regeln und in Schleifen
+    *   ANTLR: Fail-Save zur Vermeidung von Endlosschleifen
 
 *   Fehler-Alternativen in Grammatik einbauen
 

--- a/markdown/frontend/parsing/recovery.ba.md
+++ b/markdown/frontend/parsing/recovery.ba.md
@@ -23,14 +23,9 @@ tldr: |
   weiter parsen kann. Wenn mehr als ein Token fehlt oder zuviel ist, geht ANTLR in einen "Panic Mode" und
   entfernt so lange Token aus dem Eingabestrom, bis das aktuelle Token in einem *Resynchronization Set* enthalten
   ist. Die Bildung dieser Menge erinnert an die Regeln zum Bilden der *FOLLOW*-Mengen, ist aber an den Kontext
-  der "aufgerufenen" Parser-Regeln gebunden. Zusätzlich gibt es weitere Strategien zum Behandeln von Fehlern in
-  Schleifen sowie zur Vermeidung von Endlos-Fehlerbehebungsschleifen ("Fail-Save"). In Bison wird dagegen mit
-  einem speziellen *error*-Token gearbeitet und man fügt an "strategischen" Stellen Regeln der Form Regel $A \to
-  \operatorname{error} \alpha$ hinzu. Dabei ist $\alpha$ ein Token, welches zur Synchronisierung genutzt werden
-  soll. Im Fehlerfall werden so lange Token vom Stack entfernt, bis man eine Regel $A \to \operatorname{error}
-  \alpha$ anwenden kann und das *error*-Token shiften kann. Danach werden ggf. so lange Token aus dem Eingabestrom
-  entfernt, bis das Token $\alpha$ auftaucht und man die Regel mit einem *reduce* abschließen kann. Diese Form
-  der Behandlung stellt einen Kompromiss zwischen Aufwand (auch Zeit) und Nutzen dar.
+  der "aufgerufenen" Parser-Regeln gebunden. Zusätzlich gibt es weitere komplexere Strategien zum Behandeln von
+  Fehlern in Schleifen sowie zur Vermeidung von Endlos-Fehlerbehebungsschleifen ("Fail-Save"). Diese Form der
+  Behandlung stellt einen Kompromiss zwischen Aufwand (auch Zeit) und Nutzen dar.
 
   Zusätzlich kann man in der Grammatik bereits typische Fehler (vergessene Klammern oder Typos wie Dreher bei
   Schlüsselwörtern) schon über "Fehlerproduktionen" vorwegnehmen. Das bedeutet, dass man eine Regel formuliert,
@@ -54,11 +49,6 @@ fhmedia:
     name: "VL Error-Recovery"
 ---
 
-<!-- ADD
-Das tldr hier drüber enhält hier noch einige Verweise auf Bison, die vmtl auch noch rausgefummelt werden müssen.
-
-Das selbe gilt für die Beispiele. Wenn ich das richtig sehe, sind auch die teilweise für Bison/Flex und teilweise für ANTLR.
-ADD -->
 
 ## Fehler beim Parsen
 
@@ -161,10 +151,6 @@ Alternativen (Sub-Regeln) entscheiden muss.
         Problem: Dabei nicht zu weit zu springen!
     *   Spezielle Fehlerproduktionen: Spezielle Regeln in der Grammatik,
         die typische Fehler matchen.
-
-Anmerkung LR-Parser: Ein Syntaxfehler wird entdeckt, wenn die Action-Tabelle
-für Top-of-Stack und akt. Token leer ist => Stack und/oder Token modifizieren,
-aber deutlich schwieriger als bei LL ...
 :::
 
 
@@ -409,15 +395,6 @@ Es bietet sich an, in diesem Fall eine entsprechende Ausgabe zu tätigen. Dies
 wird in der folgenden Grammatik über eingebettete Aktionen erledigt.
 :::
 
-<!-- ADD
-die Überschriften im folgenden Teil dienen zur Unterscheidung Bison/Flex bzw Antrl.
-Da Bison/Flex rausfliegt, sind die verbleibenden ANTRL Überschriften nicht mehr sonderlich sinnvoll.
--->
-
-::: notes
-### ANTLR
-:::
-
 ```antlr
 stmt : 'int' ID ';'
      : 'int' ID             {notifyErrorListeners("Missing ';'");}
@@ -434,8 +411,6 @@ Letztlich steht im generierten Parser in der generierten Methode `stmt()` an
 der passenden Stelle ein Aufruf `notifyErrorListeners(Too many ';'");` ...
 :::
 
-\bigskip
-
 
 ::: notes
 ## Anmerkung: Nicht eindeutige Grammatiken
@@ -448,9 +423,7 @@ expr: ID '+' ID | INT ;
 => Was passiert bei der Eingabe: `a+b` ??! Welche Regel/Alternative soll
 jetzt matchen, d.h. welcher AST soll am Ende erzeugt werden?!
 
-### ANTLR
-
-Nicht eindeutige Grammatiken führen **nicht** zu einer Fehlermeldung,
+Nicht eindeutige Grammatiken führen in ANTLR **nicht** zu einer Fehlermeldung,
 da nicht der Nutzer mit seiner Eingabe Schuld ist, sondern das Problem
 in der Grammatik selbst steckt.
 
@@ -458,17 +431,16 @@ Während des Debuggings von Grammatiken lohnt es sich aber, diese
 Warnungen zu aktivieren. Dies kann entweder mit der Option "`-diagnostics`"
 beim Aufruf des `grun`-Tools geschehen oder über das Setzen des
 `DiagnosticErrorListener` aus der ANTLR-Runtime als ErrorListener.
-
+:::
 
 
 ## Wrap-Up
 
 *   Fehler bei `match()`: *single token deletion* oder *single token insertion*
 
-*   Panic Mode: *sync-and-return* bis Token in *Resynchronization Set* (ANTLR)
-    oder `error`-Token shiftbar (Bison)
-    *   ANTLR: Sonderbehandlung bei Start von Sub-Regeln und in Schleifen
-    *   ANTLR: Fail-Save zur Vermeidung von Endlosschleifen
+*   ANTLR: Panic Mode: *sync-and-return* bis Token in *Resynchronization Set*
+    *   Sonderbehandlung bei Start von Sub-Regeln und in Schleifen
+    *   Fail-Save zur Vermeidung von Endlosschleifen
 
 *   Fehler-Alternativen in Grammatik einbauen
 

--- a/markdown/frontend/parsing/recovery.ba.md
+++ b/markdown/frontend/parsing/recovery.ba.md
@@ -80,7 +80,7 @@ ADD -->
 
 ## Typische Fehler beim Parsing
 
-```yacc
+```antlr
 grammar VarDef;
 
 alt   : stmt | stmt2 ;
@@ -170,7 +170,7 @@ aber deutlich schwieriger als bei LL ...
 
 ## Skizze: Generierte Parser-Regeln (ANTLR)
 
-```yacc
+```antlr
 stmt  : 'int' ID ';' ;
 ```
 
@@ -266,7 +266,7 @@ def rule():
 
 \bigskip
 
-```yacc
+```antlr
 stmt : 'if' expr ':' stmt           // Following Set für "expr": {':'}
      | 'while' '(' expr ')' stmt ;  // Following Set für "expr": {')'}
 expr : term '+' INT ;               // Following Set für "term": {'+'}
@@ -373,7 +373,7 @@ Methode `setErrorHandler` des Parsers.
 
 ### Ändern der Fehlerbehandlungs-Strategie (lokal)
 
-```yacc
+```antlr
 r : ...
   ;
   catch[RecognitionException e] { throw e; }
@@ -418,7 +418,7 @@ Da Bison/Flex rausfliegt, sind die verbleibenden ANTRL Überschriften nicht mehr
 ### ANTLR4
 :::
 
-```yacc
+```antlr
 stmt : 'int' ID ';'
      : 'int' ID             {notifyErrorListeners("Missing ';'");}
      : 'int' ID ';' ';'     {notifyErrorListeners("Too many ';'");}
@@ -440,7 +440,7 @@ der passenden Stelle ein Aufruf `notifyErrorListeners(Too many ';'");` ...
 ::: notes
 ## Anmerkung: Nicht eindeutige Grammatiken
 
-```yacc
+```antlr
 stat: expr ';' | ID '+' ID ';' ;
 expr: ID '+' ID | INT ;
 ```

--- a/markdown/frontend/parsing/recovery.ma.md
+++ b/markdown/frontend/parsing/recovery.ma.md
@@ -83,12 +83,12 @@ stmt  : 'int' ID ';' ;
 stmt2 : 'int' ID '=' ID ';'  ;
 ```
 
-[ANTLR4: [VarDef.g4](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.g4), Beispiele: [VarDef.txt](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.txt)]{.bsp}
+[ANTLR: [VarDef.g4](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.g4), Beispiele: [VarDef.txt](https://github.com/Compiler-CampusMinden/CB-Vorlesung/blob/master/markdown/parsing/src/VarDef.txt)]{.bsp}
 
 
 ::::::::: notes
 *Anmerkung*: Die nachfolgenden Fehler werden am Beispiel der Grammatik
-`[VarDef.g4](src/VarDef.g4)`{=markdown} und ANTLR4 demonstriert.
+`[VarDef.g4](src/VarDef.g4)`{=markdown} und ANTLR demonstriert.
 
 ### Lexikalische Fehler
 
@@ -319,10 +319,10 @@ angenommen, dass das aktuelle Token `':'` nicht passt.
 
 
 ::: notes
-## ANTLR4: Anmerkungen Fehlerbehandlung in Sub-Regeln
+## ANTLR: Anmerkungen Fehlerbehandlung in Sub-Regeln
 
 Bei Sub-Regeln (d.h. eine Regel enthält Alternativen) oder Schleifenkonstrukten
-(d.h. eine Regel enthält `(...)*` oder `(...)+`) geht ANTLR4 etwas anders vor.
+(d.h. eine Regel enthält `(...)*` oder `(...)+`) geht ANTLR etwas anders vor.
 
 1.  Start einer Sub-Regel/Alternative: Versuch einer *single token deletion*
 
@@ -356,7 +356,7 @@ Zu Details zur Fehlerbehandlung durch ANTLR vergleiche [@Parr2014, S. 170 ff.].
 
 
 ::::::::: notes
-## ANTLR4: Ändern der Fehlerbehandlungs-Strategie
+## ANTLR: Ändern der Fehlerbehandlungs-Strategie
 
 ### Ändern der Fehlerbehandlungs-Strategie (global)
 
@@ -488,7 +488,7 @@ wird in der folgenden Grammatik über eingebettete Aktionen erledigt.
 :::
 
 ::: notes
-### ANTLR4
+### ANTLR
 :::
 
 ```antlr
@@ -528,7 +528,7 @@ void yyerror(char *s, ...) {
 ```
 
 ::: notes
-Analog zu ANTLR4 ist es auch in Flex/Bison üblich, für typische Szenarien
+Analog zu ANTLR ist es auch in Flex/Bison üblich, für typische Szenarien
 "nicht ganz korrekte" Eingaben zu akzeptieren. Dazu definiert man zusätzliche
 Lexer- oder Parser-Regeln, die diese Eingaben als das, was gemeint war akzeptieren
 und eine zusätzliche Warnung ausgeben.
@@ -555,7 +555,7 @@ expr: ID '+' ID | INT ;
 => Was passiert bei der Eingabe: `a+b` ??! Welche Regel/Alternative soll
 jetzt matchen, d.h. welcher AST soll am Ende erzeugt werden?!
 
-### ANTLR4
+### ANTLR
 
 Nicht eindeutige Grammatiken führen **nicht** zu einer Fehlermeldung,
 da nicht der Nutzer mit seiner Eingabe Schuld ist, sondern das Problem
@@ -564,7 +564,7 @@ in der Grammatik selbst steckt.
 Während des Debuggings von Grammatiken lohnt es sich aber, diese
 Warnungen zu aktivieren. Dies kann entweder mit der Option "`-diagnostics`"
 beim Aufruf des `grun`-Tools geschehen oder über das Setzen des
-`DiagnosticErrorListener` aus der ANTLR4-Runtime als ErrorListener.
+`DiagnosticErrorListener` aus der ANTLR-Runtime als ErrorListener.
 
 ### Bison
 
@@ -579,10 +579,10 @@ man im über die Option `-v` erzeugten `<name>.output`-File überprüfen.
 
 *   Fehler bei `match()`: *single token deletion* oder *single token insertion*
 
-*   Panic Mode: *sync-and-return* bis Token in *Resynchronization Set* (ANTLR4)
+*   Panic Mode: *sync-and-return* bis Token in *Resynchronization Set* (ANTLR)
     oder `error`-Token shiftbar (Bison)
-    *   ANTLR4: Sonderbehandlung bei Start von Sub-Regeln und in Schleifen
-    *   ANTLR4: Fail-Save zur Vermeidung von Endlosschleifen
+    *   ANTLR: Sonderbehandlung bei Start von Sub-Regeln und in Schleifen
+    *   ANTLR: Fail-Save zur Vermeidung von Endlosschleifen
 
 *   Fehler-Alternativen in Grammatik einbauen
 

--- a/markdown/frontend/parsing/recovery.ma.md
+++ b/markdown/frontend/parsing/recovery.ma.md
@@ -20,7 +20,7 @@ tldr: |
   geschweifte Klammer. Dieses recht einfache, aber grobe Vorgehen kann verfeinert werden, indem man versucht,
   überschüssige Token zu entfernen oder fehlender Token zu ersetzen. In ANTLR wird beispielsweise maximal ein
   fehlendes Token virtuell "ersetzt" bzw. max. ein überschüssiges Token entfernt, damit man den restlichen Code
-  weiter parsen kann. Wenn mehr als ein Token fehlt oder zuviel ist, geht ANTLR in einen "Panic Mode" und
+  weiter parsen kann. Wenn mehr als ein Token fehlt oder zu viel ist, geht ANTLR in einen "Panic Mode" und
   entfernt so lange Token aus dem Eingabestrom, bis das aktuelle Token in einem *Resynchronization Set* enthalten
   ist. Die Bildung dieser Menge erinnert an die Regeln zum Bilden der *FOLLOW*-Mengen, ist aber an den Kontext
   der "aufgerufenen" Parser-Regeln gebunden. Zusätzlich gibt es weitere Strategien zum Behandeln von Fehlern in

--- a/markdown/frontend/parsing/recovery.ma.md
+++ b/markdown/frontend/parsing/recovery.ma.md
@@ -75,7 +75,7 @@ fhmedia:
 
 ## Typische Fehler beim Parsing
 
-```yacc
+```antlr
 grammar VarDef;
 
 alt   : stmt | stmt2 ;
@@ -165,7 +165,7 @@ aber deutlich schwieriger als bei LL ...
 
 ## Skizze: Generierte Parser-Regeln (ANTLR)
 
-```yacc
+```antlr
 stmt  : 'int' ID ';' ;
 ```
 
@@ -261,7 +261,7 @@ def rule():
 
 \bigskip
 
-```yacc
+```antlr
 stmt : 'if' expr ':' stmt           // Following Set für "expr": {':'}
      | 'while' '(' expr ')' stmt ;  // Following Set für "expr": {')'}
 expr : term '+' INT ;               // Following Set für "term": {'+'}
@@ -368,7 +368,7 @@ Methode `setErrorHandler` des Parsers.
 
 ### Ändern der Fehlerbehandlungs-Strategie (lokal)
 
-```yacc
+```antlr
 r : ...
   ;
   catch[RecognitionException e] { throw e; }
@@ -394,7 +394,7 @@ Listener und fügt dann den eigenen hinzu, bevor man den Parser startet.
 
 ## Panic Mode in Bison (Error Recovery)
 
-```yacc
+```antlr
 stmt : 'int' ID ';'     { printf("%s\n", $2); }
      | error '\n'       { yyerror(); yyerrok; }
      ;
@@ -439,7 +439,7 @@ Block beendende schließende geschweifte Klammer. Beispielsweise könnte man fü
 die Sprache C bei der Definition von Statements mehrere Synchronisationspunkte
 einbauen:
 
-```yacc
+```antlr
 stmt : ...
      | error ';'    /* Synchronisation für 'return' */
      | error '}'    /* Synchronisation nach Block */
@@ -463,7 +463,7 @@ wurde, aber kein Destruktor.
 
 Beispiel:
 
-```yacc
+```antlr
 %union {
     char* str;
 }
@@ -491,7 +491,7 @@ wird in der folgenden Grammatik über eingebettete Aktionen erledigt.
 ### ANTLR4
 :::
 
-```yacc
+```antlr
 stmt : 'int' ID ';'
      : 'int' ID             {notifyErrorListeners("Missing ';'");}
      : 'int' ID ';' ';'     {notifyErrorListeners("Too many ';'");}
@@ -514,7 +514,7 @@ der passenden Stelle ein Aufruf `notifyErrorListeners(Too many ';'");` ...
 
 :::
 
-```yacc
+```antlr
 stmt : 'int' ID ';'     { $$ = $2; }
      : 'int' ID         { yyerror("unterminated id");
                           $$ = $2; }
@@ -547,7 +547,7 @@ Für weitere Details vergleiche [@Levine2009, Kap. 8].
 ::: notes
 ## Anmerkung: Nicht eindeutige Grammatiken
 
-```yacc
+```antlr
 stat: expr ';' | ID '+' ID ';' ;
 expr: ID '+' ID | INT ;
 ```


### PR DESCRIPTION
- `s/ANTLR4/ANTLR/` 
- `s/yacc/antlr/` (Code, Syntaxhighlighting)
- remove math from header
- fix notes environments (after splitting parts from bachelor stuff)
- fix formatting
- clean-up remaining references to LR parser and/or Bison in bachelor material