### PR TITLE
[Mini-Python] add links to Mini Python project

### DIFF
--- a/markdown/_index.ba.md
+++ b/markdown/_index.ba.md
@@ -16,9 +16,11 @@ Datenstrukturen und Programmiersprachenkonzepte zur Anwendung.
 
 In diesem Modul geht es um ein grundlegendes Verständnis für die wichtigsten Konzepte
 im Compilerbau. Wir schauen uns dazu relevante aktuelle Tools und Frameworks an und
-setzen diese bei der Erstellung eines kleinen Compiler-Frontends für _Mini-Python_ ein.
+setzen diese bei der Erstellung eines kleinen Compiler-Frontends für [_Mini-Python_] ein.
 
 Siehe `["Syllabus"]({{< ref "/org/syllabus" >}})`{=markdown} zu Details.
+
+[_Mini-Python_]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder
 
 
 ## Team

--- a/markdown/_index.ma.md
+++ b/markdown/_index.ma.md
@@ -16,9 +16,11 @@ Datenstrukturen und Programmiersprachenkonzepte zur Anwendung.
 
 In diesem Modul geht es um ein grundlegendes Verständnis für die wichtigsten Konzepte
 im Compilerbau. Wir schauen uns dazu relevante aktuelle Tools und Frameworks an und
-setzen diese bei der Erstellung eines kleinen Compiler-Frontends für _Mini-Python_ ein.
+setzen diese bei der Erstellung eines kleinen Compiler-Frontends für [_Mini-Python_] ein.
 
 Siehe `["Syllabus"]({{< ref "/org/syllabus" >}})`{=markdown} zu Details.
+
+[_Mini-Python_]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder
 
 
 ## Team

--- a/markdown/assignments/sheet01.ba.md
+++ b/markdown/assignments/sheet01.ba.md
@@ -10,16 +10,16 @@ hidden: true
 
 ## A1.1: Grammatik
 
-Erstellen Sie eine Grammatik für **Mini-Python**.
+Erstellen Sie eine Grammatik für [**Mini-Python**].
 
-Der auf der Wiki-Seite [Sprachumfang] definierte Umfang soll mit Ihrer
-Grammatik mindestens unterstützt werden. Dabei ist die Funktionalität
-wie in Python mit folgenden Ausnahmen:
+Der in der [Dokumentation] definierte [syntaktische] und [semantische]
+Sprachumfang soll mit Ihrer Grammatik mindestens unterstützt werden.
+Dabei ist die Funktionalität wie in Python mit folgenden Ausnahmen:
 
 *   Einrückung ist für die Funktionalität irrelevant
 *   Schleifen, Funktionen und Klassen werden mit `#end` beendet
 
-Nachfolgend einige Beispiele in Ergänzung zur Wiki-Seite [Sprachumfang]:
+Nachfolgend einige Beispiele in Ergänzung zur [Dokumentation]:
 
 1.  Beispiele für IF-Statements:
 
@@ -75,7 +75,10 @@ Nachfolgend einige Beispiele in Ergänzung zur Wiki-Seite [Sprachumfang]:
     #end
     ```
 
-[Sprachumfang]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/wiki/Definition-der-syntaktischen-Sprachelemente
+[**Mini-Python**]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder
+[Dokumentation]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/tree/master/docs
+[syntaktische]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/blob/master/docs/syntax_definition.md
+[semantische]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/blob/master/docs/semantic_definition.md
 
 
 ## A1.2: ANTLR

--- a/markdown/assignments/sheet01.ma.md
+++ b/markdown/assignments/sheet01.ma.md
@@ -10,16 +10,16 @@ hidden: true
 
 ## A1.1: Grammatik
 
-Erstellen Sie eine Grammatik für **Mini-Python**.
+Erstellen Sie eine Grammatik für [**Mini-Python**].
 
-Der auf der Wiki-Seite [Sprachumfang] definierte Umfang soll mit Ihrer
-Grammatik mindestens unterstützt werden. Dabei ist die Funktionalität
-wie in Python mit folgenden Ausnahmen:
+Der in der [Dokumentation] definierte [syntaktische] und [semantische]
+Sprachumfang soll mit Ihrer Grammatik mindestens unterstützt werden.
+Dabei ist die Funktionalität wie in Python mit folgenden Ausnahmen:
 
 *   Einrückung ist für die Funktionalität irrelevant
 *   Schleifen, Funktionen und Klassen werden mit `#end` beendet
 
-Nachfolgend einige Beispiele in Ergänzung zur Wiki-Seite [Sprachumfang]:
+Nachfolgend einige Beispiele in Ergänzung zur [Dokumentation]:
 
 1.  Beispiele für IF-Statements:
 
@@ -75,7 +75,10 @@ Nachfolgend einige Beispiele in Ergänzung zur Wiki-Seite [Sprachumfang]:
     #end
     ```
 
-[Sprachumfang]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/wiki/Definition-der-syntaktischen-Sprachelemente
+[**Mini-Python**]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder
+[Dokumentation]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/tree/master/docs
+[syntaktische]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/blob/master/docs/syntax_definition.md
+[semantische]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/blob/master/docs/semantic_definition.md
 
 
 ## A1.2: ANTLR

--- a/markdown/assignments/sheet04.ba.md
+++ b/markdown/assignments/sheet04.ba.md
@@ -13,10 +13,12 @@ hidden: true
 Erweitern Sie Ihr Projekt zu einem Compiler, indem Sie unseren [CBuilder]
 einbinden. Erzeugen Sie damit aus dem geparsten Mini-Python-Code passenden
 C-Code, den Sie mit der im [CBuilder] mitgelieferten [C-Runtime] in ein
-lauffähiges Programm übersetzen und ausführen können.
+lauffähiges Programm übersetzen und ausführen können. Beachten Sie dazu
+auch die [Dokumentation].
 
 [CBuilder]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder
 [C-Runtime]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/tree/master/c-runtime
+[Dokumentation]: https://github.com/Compiler-CampusMinden/Mini-Python-Builder/tree/master/docs
 
 
 ## A4.2: Konzepte und Features


### PR DESCRIPTION
Sowohl in der Landing Page als auch in den Übungsaufgaben wird auf das Mini-Python-Projekt verwiesen und auf die entsprechende Dokumentation dort.